### PR TITLE
fix: update desktop entry to match the official vscode package

### DIFF
--- a/vscode42.sh
+++ b/vscode42.sh
@@ -19,14 +19,15 @@ Exec=$HOME/.local/share/vscode/code %F
 Icon=$HOME/.local/share/icons/hicolor/code-icon.svg
 Type=Application
 StartupNotify=false
-StartupWMClass=vscode
+StartupWMClass=Code
 Categories=TextEditor;Development;IDE;
-MimeType=application/x-vscode-workspace;
+MimeType=application/x-code-workspace;
 Actions=new-empty-window;
 Keywords=vscode;
 
 [Desktop Action new-empty-window]
 Name=New Empty Window
+Name[cs]=Nové prázdné okno
 Name[de]=Neues leeres Fenster
 Name[es]=Nueva ventana vacía
 Name[fr]=Nouvelle fenêtre vide


### PR DESCRIPTION
Some time ago, the desktop entry provided by the official Microsoft package was updated.

The changes include a new `StartupWMClass` and `MimeType` (previously `vscode` and `application/x-vscode-workspace`, now `Code` and `application/x-code-workspace`).

This mismatch causes the new code executable to not stack up with the shortcut added to favorites, as seen in the screenshot:
![image](https://github.com/user-attachments/assets/9527f6b3-6933-477d-aa9c-6433fa6ce834)

Furthermore, localization for Czech was added in the official desktop file, and thus I've also added it.